### PR TITLE
Add missing <net/if.h> header

### DIFF
--- a/src/librecast.c
+++ b/src/librecast.c
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <fcntl.h>
 #include <ifaddrs.h>
+#include <net/if.h>
 #include <netinet/in.h>
 #include <pthread.h>
 #include <signal.h>


### PR DESCRIPTION
Previosuly when building I got:

make
make -C libs
make[1]: Entering directory '/home/justin/src/librecast/libs'
make[1]: Nothing to be done for 'libs'.
make[1]: Leaving directory '/home/justin/src/librecast/libs'
make -C src
make[1]: Entering directory '/home/justin/src/librecast/src'
cc -O3 -Wall -Wextra -Wpedantic -g -fPIC -I. -I../include -DUSE_LIBSODIUM=1 -c librecast.c
librecast.c: In function ‘lc_channel_membership_all’:
librecast.c:567:39: error: ‘IFF_MULTICAST’ undeclared (first use in this function); did you mean ‘IN_MULTICAST’?
  567 |                 if ((ifa->ifa_flags & IFF_MULTICAST) != IFF_MULTICAST
      |                                       ^~~~~~~~~~~~~
      |                                       IN_MULTICAST
librecast.c:567:39: note: each undeclared identifier is reported only once for each function it appears in
librecast.c:571:41: warning: implicit declaration of function ‘if_nametoindex’ [-Wimplicit-function-declaration]
  571 |                 req->ipv6mr_interface = if_nametoindex(ifa->ifa_name);
      |                                         ^~~~~~~~~~~~~~
make[1]: *** [Makefile:54: librecast.o] Error 1
make[1]: Leaving directory '/home/justin/src/librecast/src'
make: *** [Makefile:35: src] Error 2

After including the net/if.h:

make
make -C libs
make[1]: Entering directory '/home/justin/src/librecast/libs'
make[1]: Nothing to be done for 'libs'.
make[1]: Leaving directory '/home/justin/src/librecast/libs'
make -C src
make[1]: Entering directory '/home/justin/src/librecast/src'
cc -O3 -Wall -Wextra -Wpedantic -g -fPIC -I. -I../include -DUSE_LIBSODIUM=1 -c librecast.c
cc -shared -O3 -fPIC -Wl,-soname,liblibrecast.so.0.4 -o liblibrecast.so librecast.o errors.o hash.o if_linux.o -pthread -lpthread -lsodium
make[1]: Leaving directory '/home/justin/src/librecast/src'